### PR TITLE
Update managed-component.md

### DIFF
--- a/getting-started/managed-component.md
+++ b/getting-started/managed-component.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Managed Component
 
-Tools that provide a Managed Component can learn from multiple capabilities:
+Tools that provide a Managed Component can profit from multiple capabilities:
 
 - **Same domain**: Serve assets from the same domain as the website itself, for faster and more secure execution
 - **Website-wide events system**: Hook to a pre-existing events system that the website uses for tracking events - no need to define tool specific API

--- a/getting-started/managed-component.md
+++ b/getting-started/managed-component.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Managed Component
 
-Tools that provide a Managed Component can earn from multiple capabilities:
+Tools that provide a Managed Component can learn from multiple capabilities:
 
 - **Same domain**: Serve assets from the same domain as the website itself, for faster and more secure execution
 - **Website-wide events system**: Hook to a pre-existing events system that the website uses for tracking events - no need to define tool specific API


### PR DESCRIPTION
Tools that provide a Managed Component can _earn_ from multiple capabilities:

1.  Earn does not seem to be the correct word.
2.  I imagine earn made it through spell checker.

Fix:
I am not sure what is supposed to go there, but it seems like, "learn".

-----------------

Not sure what this should be given the context, maybe they can extend multiple capabilities, or inheritm, but learn seems best.

Tools that provide a Managed Component can learn from multiple capabilities: