### PR TITLE
Correct widget docs code syntax

### DIFF
--- a/specs/embed-and-widgets/widgets.md
+++ b/specs/embed-and-widgets/widgets.md
@@ -3,18 +3,16 @@
 Floating widgets are not replacing an element, instead, they are appended to the `<body>` tag of the page. Inside the External Component, a floating tweet widget will be defined like this:
 
 ```js
-manager.registerWidget("floatingTweet", ({ element }) => {
+manager.registerWidget(async () => {
   const tweetId = element.attributes["tweet-id"];
   const tweet = await manager.useCache(
     "tweet-" + tweetId,
     await(await fetch("https://api.twitter.com/tweet/" + tweetId)).json()
   );
 
-  element.render(
-    await manager.useCache(
-      "widget",
-      pug.compile("templates/floating-widget.pug", { tweet })
-    )
+  return await manager.useCache(
+    "widget",
+    pug.compile("templates/floating-widget.pug", { tweet })
   );
 });
 ```


### PR DESCRIPTION
When having a look at the usages for the `registerWidget` function, it seems that the syntax is a bit different from what it is the docs: https://github.com/managed-components/demo/blob/2b57e10c60b7203c5305c67a046c17e09f88adcf/src/index.ts#L156

It seems to me the argument of the function should be an async function that returns the rendered HTML. Let me know if that makes sense.